### PR TITLE
Fix #99: Set default view mode to dark mode

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -17,11 +17,8 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
         if (savedTheme) {
             return savedTheme;
         }
-        // Check system preference
-        if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-            return "dark";
-        }
-        return "light";
+        // Default to dark mode
+        return "dark";
     });
 
     useEffect(() => {


### PR DESCRIPTION
# Fix Default View Mode to Dark Mode

## Issue
Fixes #99 - Changed the default theme from light mode to dark mode for better user experience.

## Changes Made
- Modified `ThemeContext.tsx` to set dark mode as the default theme
- Updated initial theme logic to prioritize dark mode for new users
- Existing users' saved preferences remain unaffected

## Implementation
The default theme now initializes to `"dark"` instead of checking system preferences. Users without a saved theme preference will automatically see dark mode on their first visit.

## Testing
To verify the changes:
1. Clear browser localStorage or open an incognito window
2. Navigate to the application
3. Confirm dark mode loads by default

## Files Modified
- `src/context/ThemeContext.tsx`