### PR TITLE
Fix documentation links to use root-based paths

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,10 +6,10 @@ This guide explains how to get started, follow best practices, and submit high�
 ---
 
 ## Quick Links
-- [Setup Guide](SETUP.md) – Development environment setup  
-- [Architecture](ARCHITECTURE.md) – System overview  
-- [Database Schema](DATABASE.md) – Database documentation  
-- [Code of Conduct](CODE_OF_CONDUCT.md) – Community guidelines   
+- [Setup Guide](/docs/SETUP.md) – Development environment setup  
+- [Architecture](/docs/ARCHITECTURE.md) – System overview  
+- [Database Schema](/docs/DATABASE.md) – Database documentation  
+- [Code of Conduct](/docs/CODE_OF_CONDUCT.md) – Community guidelines   
 
 ---
 
@@ -37,7 +37,7 @@ cd devconnect
 
 ## Development Setup
 
-Follow the detailed [Setup Guide](SETUP.md).
+Follow the detailed [Setup Guide](/docs/SETUP.md).
 
 Basic steps:
 
@@ -306,8 +306,8 @@ All contributors are listed in **CONTRIBUTORS.md** 💙
 ---
 
 ## Need Help?
-- Review [SETUP.md](SETUP.md)  
-- Check [ARCHITECTURE.md](ARCHITECTURE.md)  
+- Review [SETUP.md](/docs/SETUP.md)  
+- Check [ARCHITECTURE.md](/docs/ARCHITECTURE.md)  
 - Explore existing code patterns  
 - Open a discussion  
 


### PR DESCRIPTION
 📝 Description
  Fixes incorrect relative links in CONTRIBUTING.md by updating them to use root-based paths    (e.g.,/docs/...).
   This ensures all documentation links work correctly regardless of the current directory.

## 🎯 Type of Change
- [X] 📚 Documentation update


## 🔗 Related Issues
Closes #101

## 📋 Changes Made
<!-- List the key changes in this PR -->
- [X] Updated documentation links to start from the root directory
- [X] Fixed broken references to setup, architecture, and database docs
- [X] Ensured consistency across all links in CONTRIBUTING.md

## 🧪 Testing
- [X] Manual testing completed

**Testing Steps:**
1. Opened CONTRIBUTING.md
2. Clicked each documentation link
3. Verified all links resolve correctly from GitHub UI

## 🎨 Screenshots/Demo
N/A (documentation-only change)

## 📦 Dependencies
- [X] No new dependencies

## ✅ Checklist
### Code Quality
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

### Testing & Functionality
- [X] I have tested my changes thoroughly

### Documentation
- [X] I have updated the documentation accordingly

### Git & Commits
- [X] My commits have clear, descriptive messages
- [X] My branch is up to date with the base branch
- [X] I have not included unnecessary commits

### Breaking Changes
- [X] This PR does not introduce breaking changes

## 📝 Additional Context
This improves contributor experience by preventing broken documentation links when navigating the repository.

## 🔍 Reviewer Notes
Please verify that all documentation links resolve correctly from different directories.

## 🚀 Deployment Notes
No deployment steps required.