### PR TITLE
fix: update input text colors for light/dark theme

### DIFF
--- a/src/pages/Contributors.tsx
+++ b/src/pages/Contributors.tsx
@@ -20,10 +20,10 @@ const Contributors = () => {
   return (
     <section className="mx-auto max-w-7xl px-6 py-16">
       <div className="mb-10 text-center">
-        <h1 className="text-4xl font-bold text-slate-100">
+        <h1 style={{ color: 'var(--text-primary)' }} className="text-4xl font-bold">
           Hall of Fame
         </h1>
-        <p className="mt-3 text-slate-400">
+        <p style={{ color: 'var(--text-secondary)' }} className="mt-3">
           The amazing developers who contributed code and ideas.
         </p>
       </div>
@@ -34,12 +34,17 @@ const Contributors = () => {
           placeholder="Search contributors..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="
-            w-full rounded-lg border border-slate-800
-            bg-slate-950 px-4 py-3 text-black /* यहाँ text-black कर दिया */
-            placeholder-slate-500
-            focus:border-cyan-400 focus:outline-none
-          "
+          style={{
+            width: "100%",
+            borderRadius: "0.5rem",
+            padding: "0.75rem 1rem",
+            border: "1px solid var(--border-color)",
+            backgroundColor: "var(--bg-color)",
+            color: "var(--text-color)",
+            outline: "none",
+            transition: "all 0.2s ease"
+          }}
+          className="rounded-lg focus:border-cyan-400 focus:outline-none"
         />
       </div>
 


### PR DESCRIPTION
📝 Description

Fixes search input text color in Contributors page to work properly in both light and dark themes.

🎯 Type of Change
🐛 Bug fix (non-breaking change that fixes an issue)
🎨 UI/UX improvement

🔗 Related Issues 
#146 
Closes issue with search input text not visible in different themes

📋 Changes Made

Updated input styling to use CSS variables for theme support
Light theme: Black text on white background
Dark theme: White text on black background
Added CSS variables for consistent theming

Screenshots: 
<img width="1440" height="814" alt="image" src="https://github.com/user-attachments/assets/405ad0e6-acbb-4e66-bd72-9e6daa8019a1" />
<img width="1440" height="815" alt="image" src="https://github.com/user-attachments/assets/8babf8c0-4e87-464c-ac7c-cad7e6cfc600" />
